### PR TITLE
[abstraction-rtos] add RISC-V MCU support

### DIFF
--- a/abstraction-rtos/include/cyabs_rtos_internal.h
+++ b/abstraction-rtos/include/cyabs_rtos_internal.h
@@ -30,6 +30,9 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+
+#ifndef __riscv
+
 #if !defined (COMPONENT_CAT5)
 #include <cmsis_compiler.h>
 #endif
@@ -51,6 +54,9 @@ static inline bool is_in_isr(void)
     return (__get_IPSR() != 0);
     #endif
 }
+#else
+extern bool is_in_isr(void);
+#endif
 
 
 #if defined(__cplusplus)

--- a/abstraction-rtos/source/COMPONENT_FREERTOS/cyabs_rtos_dsram.c
+++ b/abstraction-rtos/source/COMPONENT_FREERTOS/cyabs_rtos_dsram.c
@@ -23,7 +23,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **************************************************************************************************/
+#ifndef __riscv
 #include <cmsis_compiler.h> // For __WEAK
+#endif
 #include "FreeRTOS.h"
 #include "cyabs_rtos.h"
 #include "cyabs_rtos_dsram.h"


### PR DESCRIPTION
- removed the Cortex-M related include and register access